### PR TITLE
Fix mistake in Python wrapper's usage example

### DIFF
--- a/wrappers/python/README.md
+++ b/wrappers/python/README.md
@@ -13,7 +13,7 @@ import cv2
 import zxing
 
 img = cv2.imread('myimage.png')
-result = zxing.decode(img)
+result = zxing.read_barcode(img)
 if result.valid:
     print("Found barcode with value '{}' (format: {})".format(result.text, str(result.format))) 
 else:


### PR DESCRIPTION
The Python wrapper's decoding function has been [renamed](https://github.com/nu-book/zxing-cpp/commit/91f485b2b8f0be6a63f7fc47a95bcc44d742382f#diff-976f1878f2d366acf21e1a534af178578a2fdecc327ece9671e5d61ea9e93c8bL20) from "decode" to "read_barcode", but the usage example in README.md still uses "decode", so I make this pull request to correct the mistake.

![](https://user-images.githubusercontent.com/47057319/105580184-cdf10f80-5dc5-11eb-9490-fa5da8bea0f4.png)
